### PR TITLE
[13] sale_blanket_order - Fix wrong taxes on sale order

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -629,12 +629,12 @@ class BlanketOrderLine(models.Model):
             if self.env.uid == SUPERUSER_ID:
                 company_id = self.env.company.id
                 self.taxes_id = fpos.map_tax(
-                    self.product_id.supplier_taxes_id.filtered(
+                    self.product_id.taxes_id.filtered(
                         lambda r: r.company_id.id == company_id
                     )
                 )
             else:
-                self.taxes_id = fpos.map_tax(self.product_id.supplier_taxes_id)
+                self.taxes_id = fpos.map_tax(self.product_id.taxes_id)
 
     @api.depends(
         "sale_lines.order_id.state",


### PR DESCRIPTION
Populated taxes are taken from supplier_taxes_id to sales order we must use taxes_id from client taxes to sales order.